### PR TITLE
YETUS-267 Follow redirect with curl when downloading patches

### DIFF
--- a/precommit/core.d/patchfiles.sh
+++ b/precommit/core.d/patchfiles.sh
@@ -31,7 +31,7 @@ function generic_locate_patch
     return 1
   fi
 
-  ${CURL} --silent \
+  ${CURL} --silent -L \
           --output "${output}" \
          "${input}"
   if [[ $? != 0 ]]; then


### PR DESCRIPTION
Simple change which fixed it for me locally, but I'm surprised that I needed to change this at all. I would have expected others to have run into this before me.