### PR TITLE
YETUS-614. github_jira_bridge is not working after the update of ASF JIRA

### DIFF
--- a/precommit/test-patch.d/github.sh
+++ b/precommit/test-patch.d/github.sh
@@ -99,13 +99,12 @@ function github_parse_args
 function github_jira_bridge
 {
   declare fileloc=$1
+  declare jsonloc=$2
   declare urlfromjira
 
-  # the JIRA issue has already been downloaded. So let's find the URL.
   # shellcheck disable=SC2016
-
   urlfromjira=$(${AWK} "match(\$0,\"${GITHUB_BASE_URL}/[^ ]*patch[ &\\\"]\"){url=substr(\$0,RSTART,RLENGTH-1)}
-                        END{if (url) print url}" "${PATCH_DIR}/jira" )
+                        END{if (url) print url}" "${jsonloc}" )
   if [[ -z $urlfromjira ]]; then
     # This is currently the expected path, as github pull requests are not common
     return 1

--- a/precommit/test-patch.d/jira.sh
+++ b/precommit/test-patch.d/jira.sh
@@ -153,6 +153,7 @@ function jira_locate_patch
 {
   declare input=$1
   declare fileloc=$2
+  declare jsonloc
   declare relativeurl
   declare retval
   declare found=false
@@ -174,7 +175,12 @@ function jira_locate_patch
   # that is a github patch file or pull request
   if [[ -n "${GITHUB_BASE_URL}" ]]; then
     jira_determine_issue "${input}"
-    github_jira_bridge "${fileloc}"
+    # Download information via REST API
+    jsonloc="${PATCH_DIR}/jira-json"
+    jira_http_fetch "rest/api/2/issue/${input}" "${jsonloc}"
+    # Parse the downloaded information to check if the issue is
+    # just a pointer to GitHub.
+    github_jira_bridge "${fileloc}" "${jsonloc}"
     if [[ $? -eq 0 ]]; then
       echo "${input} appears to be a Github PR. Switching Modes."
       return 0


### PR DESCRIPTION
Manually tested by the following command:
```
$ ./precommit/smart-apply-patch.sh YETUS-605 --project=yetus --plugins=github,jira --debug
```