### PR TITLE
YETUS-619. audience-annottaions-jdiff doclet does not work on Java 9

### DIFF
--- a/audience-annotations-component/audience-annotations-jdiff/pom.xml
+++ b/audience-annotations-component/audience-annotations-jdiff/pom.xml
@@ -46,13 +46,24 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <!-- Version and location set in project pom -->
-      <groupId>jdk.tools</groupId>
-      <artifactId>jdk.tools</artifactId>
-      <scope>system</scope>
-      <!-- Mark as optional so that it isn't taken transitively -->
-      <optional>true</optional>
-    </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <id>jdk1.8</id>
+      <activation>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <!-- Version and location set in project pom -->
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+          <scope>system</scope>
+          <!-- Mark as optional so that it isn't taken transitively -->
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/audience-annotations-component/audience-annotations/pom.xml
+++ b/audience-annotations-component/audience-annotations/pom.xml
@@ -33,14 +33,22 @@
   <name>Apache Yetus - Audience Annotations</name>
   <packaging>jar</packaging>
 
-  <dependencies>
-    <dependency>
-      <!-- Version and location set in project pom -->
-      <groupId>jdk.tools</groupId>
-      <artifactId>jdk.tools</artifactId>
-      <scope>system</scope>
-      <!-- Mark as optional so that it isn't taken transitively -->
-      <optional>true</optional>
-    </dependency>
-  </dependencies>
+  <profiles>
+    <profile>
+      <id>jdk1.8</id>
+      <activation>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <!-- Version and location set in project pom -->
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+          <scope>system</scope>
+          <!-- Mark as optional so that it isn't taken transitively -->
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/yetus-project/pom.xml
+++ b/yetus-project/pom.xml
@@ -166,23 +166,6 @@
         </dependencies>
       </dependencyManagement>
     </profile>
-    <profile>
-      <id>jdk1.9</id>
-      <activation>
-        <jdk>1.9</jdk>
-      </activation>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>jdk.tools</groupId>
-            <artifactId>jdk.tools</artifactId>
-            <version>1.9</version>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
Change:

* Created `jdk8` profile and moved jdk.tools direct dependency into the profile.

Testing:

* Compiled the modules successfully on both Java 8 and Java 9 on my local.