### PR TITLE
YETUS-623. docker-cleanup doesn't support options which start with docker correctly

### DIFF
--- a/precommit/core.d/docker.sh
+++ b/precommit/core.d/docker.sh
@@ -55,8 +55,9 @@ function docker_usage
     yetus_add_option "--dockerprivd=<bool>" "Run docker in privileged mode (default: '${DOCKER_ENABLE_PRIVILEGED}')"
   fi
   yetus_add_option "--dockerdelrep" "In Docker mode, only report image/container deletions, not act on them"
-  yetus_add_option "--dockermemlimit=<num>" "Limit a Docker container's memory usage (default: ${DOCKER_MEMORY})"
-
+  if [[ "${DOCKER_CLEANUP_CMD}" == false ]]; then
+    yetus_add_option "--dockermemlimit=<num>" "Limit a Docker container's memory usage (default: ${DOCKER_MEMORY})"
+  fi
 }
 
 ## @description  Docker-specific argument parsing

--- a/precommit/docker-cleanup.sh
+++ b/precommit/docker-cleanup.sh
@@ -143,6 +143,8 @@ function parse_args
       ;;
     esac
   done
+
+  docker_parse_args "$@"
 }
 
 ## @description  Print the usage information


### PR DESCRIPTION
dockermemlimit is used only with `docker run` command, so disabled it for docker-cleanup.