### PR TITLE
YETUS-712 Bump Hadolint to 1.15.0

### DIFF
--- a/precommit/test-patch-docker/Dockerfile
+++ b/precommit/test-patch-docker/Dockerfile
@@ -186,7 +186,7 @@ RUN apt-get -q update && apt-get -q install --no-install-recommends -y shellchec
 # Install hadolint
 ####
 RUN curl -L -s -S \
-   https://github.com/hadolint/hadolint/releases/download/v1.11.1/hadolint-Linux-x86_64 \
+   https://github.com/hadolint/hadolint/releases/download/v1.15.0/hadolint-Linux-x86_64 \
    -o /bin/hadolint && \
    chmod a+rx /bin/hadolint && \
    shasum -a 512 /bin/hadolint | \


### PR DESCRIPTION
Update Hadolint from 1.11.1 to 1.15.0: https://issues.apache.org/jira/browse/YETUS-712