### PR TITLE
YETUS-816. Improve hadoop personality to support ozone/hdds projects

### DIFF
--- a/precommit/src/main/shell/personality/hadoop.sh
+++ b/precommit/src/main/shell/personality/hadoop.sh
@@ -18,7 +18,6 @@
 # SHELLDOC-IGNORE
 #
 # Override these to match Apache Hadoop's requirements
-
 personality_plugins "all,-ant,-gradle,-scalac,-scaladoc"
 
 ## @description  Globals specific to this personality
@@ -406,7 +405,7 @@ function personality_modules
   extra="-Ptest-patch ${extra}"
   OZONE_CHANGED=false
   CORE_HADOOP_CHANGED=false
-  for module in $CHANGED_MODULES
+  for module in "${CHANGED_MODULES[@]}"
   do
     if [[ "$module" =~ "hdds" ]]; then
       OZONE_CHANGED=true
@@ -423,7 +422,9 @@ function personality_modules
 
   if [ "$CORE_HADOOP_CHANGED" = false ] && [ "$OZONE_CHANGED" = true ]; then
     if [ "$testtype" != "mvnsite" ] && [ "$testtype" != "shadedclient" ]; then
+      #shellcheck disable=SC2086
       personality_enqueue_module hadoop-hdds ${extra}
+      #shellcheck disable=SC2086
       personality_enqueue_module hadoop-ozone ${extra}
     fi
   else

--- a/precommit/src/main/shell/personality/hadoop.sh
+++ b/precommit/src/main/shell/personality/hadoop.sh
@@ -422,8 +422,10 @@ function personality_modules
   fi
 
   if [ "$CORE_HADOOP_CHANGED" = false ] && [ "$OZONE_CHANGED" = true ]; then
-    personality_enqueue_module hadoop-hdds ${extra}
-    personality_enqueue_module hadoop-ozone ${extra}
+    if [ "$testtype" != "mvnsite" ] && [ "$testtype" != "shadedclient" ]; then
+      personality_enqueue_module hadoop-hdds ${extra}
+      personality_enqueue_module hadoop-ozone ${extra}
+    fi
   else
     for module in $(hadoop_order ${ordering}); do
       # shellcheck disable=SC2086

--- a/precommit/src/main/shell/personality/hadoop.sh
+++ b/precommit/src/main/shell/personality/hadoop.sh
@@ -404,11 +404,32 @@ function personality_modules
   fi
 
   extra="-Ptest-patch ${extra}"
-
-  for module in $(hadoop_order ${ordering}); do
-    # shellcheck disable=SC2086
-    personality_enqueue_module ${module} ${extra}
+  OZONE_CHANGED=false
+  CORE_HADOOP_CHANGED=false
+  for module in $CHANGED_MODULES
+  do
+    if [[ "$module" =~ "hdds" ]]; then
+      OZONE_CHANGED=true
+    elif [[ "$module" =~ "ozone" ]]; then
+      OZONE_CHANGED=true
+    else
+      CORE_HADOOP_CHANGED=true
+    fi
   done
+
+  if [ "$OZONE_CHANGED" = true ]; then
+    extra="-Phdds ${extra}"
+  fi
+
+  if [ "$CORE_HADOOP_CHANGED" = false ] && [ "$OZONE_CHANGED" = true ]; then
+    personality_enqueue_module hadoop-hdds ${extra}
+    personality_enqueue_module hadoop-ozone ${extra}
+  else
+    for module in $(hadoop_order ${ordering}); do
+      # shellcheck disable=SC2086
+      personality_enqueue_module ${module} ${extra}
+    done
+  fi
 }
 
 ## @description  Add tests based upon personality needs


### PR DESCRIPTION
Ozone/Hdds projects are not handled very well in the hadoop personality as in case of an ozone change all the hdds/ozone projects should be built and tested