### PR TITLE
YETUS-893 Updates link to doclet javadoc

### DIFF
--- a/audience-annotations-component/audience-annotations-jdiff/src/main/java/org/apache/yetus/audience/tools/ExcludePrivateAnnotationsJDiffDoclet.java
+++ b/audience-annotations-component/audience-annotations-jdiff/src/main/java/org/apache/yetus/audience/tools/ExcludePrivateAnnotationsJDiffDoclet.java
@@ -27,7 +27,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
 /**
- * A <a href="https://java.sun.com/javase/6/docs/jdk/api/javadoc/doclet/">Doclet</a>
+ * A <a href="https://docs.oracle.com/javase/8/docs/jdk/api/javadoc/doclet/">Doclet</a>
  * for excluding elements that are annotated with
  * {@link org.apache.yetus.audience.InterfaceAudience.Private} or
  * {@link org.apache.yetus.audience.InterfaceAudience.LimitedPrivate}.

--- a/audience-annotations-component/audience-annotations/src/main/java/org/apache/yetus/audience/tools/ExcludePrivateAnnotationsStandardDoclet.java
+++ b/audience-annotations-component/audience-annotations/src/main/java/org/apache/yetus/audience/tools/ExcludePrivateAnnotationsStandardDoclet.java
@@ -26,7 +26,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
 /**
- * A <a href="https://java.sun.com/javase/6/docs/jdk/api/javadoc/doclet/">Doclet</a>
+ * A <a href="https://docs.oracle.com/javase/8/docs/jdk/api/javadoc/doclet/">Doclet</a>
  * for excluding elements that are annotated with
  * {@link org.apache.yetus.audience.InterfaceAudience.Private} or
  * {@link org.apache.yetus.audience.InterfaceAudience.LimitedPrivate}.

--- a/audience-annotations-component/audience-annotations/src/main/java/org/apache/yetus/audience/tools/IncludePublicAnnotationsStandardDoclet.java
+++ b/audience-annotations-component/audience-annotations/src/main/java/org/apache/yetus/audience/tools/IncludePublicAnnotationsStandardDoclet.java
@@ -26,7 +26,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
 /**
- * A <a href="https://java.sun.com/javase/6/docs/jdk/api/javadoc/doclet/">Doclet</a>
+ * A <a href="https://docs.oracle.com/javase/8/docs/jdk/api/javadoc/doclet/">Doclet</a>
  * that only includes class-level elements that are annotated with
  * {@link org.apache.yetus.audience.InterfaceAudience.Public}.
  * Class-level elements with no annotation are excluded.


### PR DESCRIPTION
Hi,

Updated links from https://java.sun.com/javase/6/docs/jdk/api/javadoc/doclet/ to https://docs.oracle.com/javase/8/docs/jdk/api/javadoc/doclet/