### PR TITLE
YETUS-926. Add visual separation to console report summary

### DIFF
--- a/precommit/src/main/shell/core.d/builtin-bugsystem.sh
+++ b/precommit/src/main/shell/core.d/builtin-bugsystem.sh
@@ -124,7 +124,9 @@ function console_finalreport
     ${SED} -e '1d' "${commentfile1}"  > "${commentfile2}"
 
     if [[ "${vote}" = "H" ]]; then
+      echo "+---------------------------------------------------------------------------"
       printf '|      | %*s |            |%-s\n' ${seccoladj} " " "${normaltop}"
+      echo "+---------------------------------------------------------------------------"
     else
       printf '| %4s | %*s | %-10s |%-s\n' "${vote}" ${seccoladj} \
         "${subs}" "${calctime}" "${normaltop}"


### PR DESCRIPTION
The final output table is a wall of text. If you squint a little, you
can see that there are subsections contained within. Add some visual
separation between sections so that one can navigate the results.

Before this change:

```
| Vote |       Subsystem |  Runtime   | Comment
============================================================================
|      |                 |            | Prechecks
|  +1  |        dupname  |   0m  0s   | No case conflicting files found.
|  +1  |      hbaseanti  |   0m  0s   | Patch does not have any anti-patterns.
|  +1  |        @author  |   0m  0s   | The patch does not contain any @author
|      |                 |            | tags.
|  +1  |     test4tests  |   0m  0s   | The patch appears to include 4 new or
|      |                 |            | modified test files.
|      |                 |            | master Compile Tests
|  +1  |     mvninstall  |   4m  6s   | master passed
|  +1  |        compile  |   0m 31s   | master passed
|  +1  |     checkstyle  |   0m 37s   | master passed
|  +1  |     shadedjars  |   2m 30s   | branch has no errors when building our
|      |                 |            | shaded downstream artifacts.
|  +1  |        javadoc  |   0m 22s   | master passed
|   0  |       spotbugs  |   3m 20s   | Used deprecated FindBugs config;
|      |                 |            | considering switching to SpotBugs.
|  +1  |       findbugs  |   3m 19s   | master passed
|      |                 |            | Patch Compile Tests
|  +1  |     mvninstall  |   2m 49s   | the patch passed
|  +1  |        compile  |   0m 30s   | the patch passed
|  +1  |          javac  |   0m 30s   | the patch passed
|  -0  |     checkstyle  |   0m 34s   | hbase-server: The patch generated 8 new
|      |                 |            | + 234 unchanged - 7 fixed = 242 total
|      |                 |            | (was 241)
|  +1  |     whitespace  |   0m  0s   | The patch has no whitespace issues.
|  +1  |     shadedjars  |   2m 31s   | patch has no errors when building our
|      |                 |            | shaded downstream artifacts.
|  +1  |    hadoopcheck  |  11m 22s   | Patch does not cause any errors with
|      |                 |            | Hadoop 2.8.5 2.9.2 or 3.1.1 3.1.2.
|  +1  |        javadoc  |   0m 18s   | the patch passed
|  +1  |       findbugs  |   3m 19s   | the patch passed
|      |                 |            | Other Tests
|  -1  |           unit  |  26m 48s   | hbase-server in the patch failed.
|  +1  |     asflicense  |   0m 22s   | The patch does not generate ASF License
|      |                 |            | warnings.
|      |                 |  62m 50s   |
```

After:

```
| Vote |       Subsystem |  Runtime   | Comment
============================================================================
+---------------------------------------------------------------------------
|      |                 |            | Prechecks
+---------------------------------------------------------------------------
|  +1  |        dupname  |   0m  0s   | No case conflicting files found.
|  +1  |      hbaseanti  |   0m  0s   | Patch does not have any anti-patterns.
|  +1  |        @author  |   0m  0s   | The patch does not contain any @author
|      |                 |            | tags.
|  +1  |     test4tests  |   0m  0s   | The patch appears to include 4 new or
|      |                 |            | modified test files.
+---------------------------------------------------------------------------
|      |                 |            | master Compile Tests
+---------------------------------------------------------------------------
|  +1  |     mvninstall  |   3m 54s   | master passed
|  +1  |        compile  |   0m 30s   | master passed
|  +1  |     checkstyle  |   0m 37s   | master passed
|  +1  |     shadedjars  |   2m 27s   | branch has no errors when building our
|      |                 |            | shaded downstream artifacts.
|  +1  |        javadoc  |   0m 23s   | master passed
|   0  |       spotbugs  |   3m 23s   | Used deprecated FindBugs config;
|      |                 |            | considering switching to SpotBugs.
|  +1  |       findbugs  |   3m 22s   | master passed
+---------------------------------------------------------------------------
|      |                 |            | Patch Compile Tests
+---------------------------------------------------------------------------
|  +1  |     mvninstall  |   2m 42s   | the patch passed
|  +1  |        compile  |   0m 29s   | the patch passed
|  +1  |          javac  |   0m 29s   | the patch passed
|  -0  |     checkstyle  |   0m 34s   | hbase-server: The patch generated 8 new
|      |                 |            | + 234 unchanged - 7 fixed = 242 total
|      |                 |            | (was 241)
|  +1  |     whitespace  |   0m  0s   | The patch has no whitespace issues.
|  +1  |     shadedjars  |   2m 27s   | patch has no errors when building our
|      |                 |            | shaded downstream artifacts.
|  +1  |    hadoopcheck  |  11m 36s   | Patch does not cause any errors with
|      |                 |            | Hadoop 2.8.5 2.9.2 or 3.1.1 3.1.2.
|  +1  |        javadoc  |   0m 19s   | the patch passed
|  +1  |       findbugs  |   3m 22s   | the patch passed
+---------------------------------------------------------------------------
|      |                 |            | Other Tests
+---------------------------------------------------------------------------
|  -1  |           unit  |  51m 52s   | hbase-server in the patch failed.
|  +1  |     asflicense  |   0m 11s   | The patch does not generate ASF License
|      |                 |            | warnings.
|      |                 |  87m 43s   |
```