### PR TITLE
YETUS-927. GITHUB_PASSWD environment variable is not effective

### DIFF
--- a/precommit/src/main/shell/test-patch.d/github.sh
+++ b/precommit/src/main/shell/test-patch.d/github.sh
@@ -57,7 +57,7 @@ function github_usage
   yetus_add_option "--github-api-url=<url>" "The URL of the API for github (default: '${GITHUB_API_URL}')"
   yetus_add_option "--github-base-url=<url>" "The URL of the github server (default:'${GITHUB_BASE_URL}')"
 # Do not extract GITHUB_PASSWD environment variable
-  yetus_add_option "--github-password=<pw>" "Github password (or OAuth token) (default: 'GITHUB_PASSWD')"
+  yetus_add_option "--github-password=<pw>" "Github password (or OAuth token) (default: 'GITHUB_PASSWD' environment variable)"
   yetus_add_option "--github-repo=<repo>" "github repo to use (default:'${GITHUB_REPO}')"
   yetus_add_option "--github-user=<user>" "Github user [default: ${GITHUB_USER}]"
   yetus_add_option "--github-use-emoji-vote" "Whether to use emoji to represent the vote result on github [default: ${GITHUB_USE_EMOJI_VOTE}]"

--- a/precommit/src/main/shell/test-patch.d/github.sh
+++ b/precommit/src/main/shell/test-patch.d/github.sh
@@ -33,8 +33,8 @@ GITHUB_API_URL="https://api.github.com"
 GITHUB_REPO=""
 
 # user settings
-GITHUB_PASSWD=""
-GITHUB_USER=""
+GITHUB_PASSWD="${GITHUB_PASSWD}"
+GITHUB_USER="${GITHUB_USER}"
 GITHUB_ISSUE=""
 GITHUB_USE_EMOJI_VOTE=false
 
@@ -56,7 +56,8 @@ function github_usage
 
   yetus_add_option "--github-api-url=<url>" "The URL of the API for github (default: '${GITHUB_API_URL}')"
   yetus_add_option "--github-base-url=<url>" "The URL of the github server (default:'${GITHUB_BASE_URL}')"
-  yetus_add_option "--github-password=<pw>" "Github password (or OAuth token)"
+# Do not extract GITHUB_PASSWD environment variable
+  yetus_add_option "--github-password=<pw>" "Github password (or OAuth token) (default: 'GITHUB_PASSWD')"
   yetus_add_option "--github-repo=<repo>" "github repo to use (default:'${GITHUB_REPO}')"
   yetus_add_option "--github-user=<user>" "Github user [default: ${GITHUB_USER}]"
   yetus_add_option "--github-use-emoji-vote" "Whether to use emoji to represent the vote result on github [default: ${GITHUB_USE_EMOJI_VOTE}]"


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/YETUS-927

* Reflect `GITHUB_USER` and `GITHUB_PASSWD` env vars.