### PR TITLE
YETUS-974. start-build-env.sh fails

### DIFF
--- a/precommit/src/main/shell/test-patch-docker/Dockerfile
+++ b/precommit/src/main/shell/test-patch-docker/Dockerfile
@@ -204,6 +204,7 @@ RUN apt-get -q update && apt-get -q install --no-install-recommends -y \
 RUN pip2 install -v \
         astroid==1.6.5 \
         configparser==4.0.2 \
+        isort==4.3.21 \
         pylint==1.9.2 \
         python-dateutil==2.7.3 \
     && rm -rf /root/.cache


### PR DESCRIPTION
Use the latest isort version that supports Python 2.