### PR TITLE
YETUS-1028. Various missing github annotations

### DIFF
--- a/precommit/src/main/shell/robots.d/githubactions.sh
+++ b/precommit/src/main/shell/robots.d/githubactions.sh
@@ -18,6 +18,9 @@
 
 if [[ "${GITHUB_ACTIONS}" == true ]] &&
   declare -f compile_cycle >/dev/null; then
+
+  echo "::group::Bootstrap"
+
   # shellcheck disable=SC2034
   ROBOT=true
   # shellcheck disable=SC2034
@@ -79,3 +82,7 @@ function githubactions_set_plugin_defaults
   GITHUB_REPO="${GITHUB_REPOSITORY}"
 }
 
+function githubactions_cleanup_and_exit
+{
+  echo "::endgroup::"
+}

--- a/precommit/src/main/shell/test-patch.d/asflicense.sh
+++ b/precommit/src/main/shell/test-patch.d/asflicense.sh
@@ -143,17 +143,16 @@ function asflicense_tests
   echo "There appear to be ${numpatch} ASF License warnings after applying the patch."
   if [[ -n ${numpatch}
      && ${numpatch} -gt 0 ]] ; then
+
+    # shellcheck disable=SC2016
+    "${GREP}" '\!?????' "${PATCH_DIR}/patch-asflicense.txt" \
+      | "${SED}" -e "s,${BASEDIR},,g" -e "s, \!????? ,,g" \
+      | "${AWK}" '{print $1":1:Missing Apache License"}' \
+    >>  "${PATCH_DIR}/results-asflicense.txt"
     add_vote_table_v2 -1 asflicense \
-      "@@BASE@@/patch-asflicense-problems.txt" \
+      "@@BASE@@/results-asflicense.txt" \
       "${BUILDMODEMSG} generated ${numpatch} ASF License warnings."
-
-    echo "Lines that start with ????? in the ASF License "\
-        "report indicate files that do not have an Apache license header:" \
-          > "${PATCH_DIR}/patch-asflicense-problems.txt"
-
-    ${GREP} '\!?????' "${PATCH_DIR}/patch-asflicense.txt" \
-    >>  "${PATCH_DIR}/patch-asflicense-problems.txt"
-
+    bugsystem_linecomments_queue asflicense "${PATCH_DIR}/results-asflicense.txt"
     return 1
   fi
   add_vote_table_v2 1 asflicense "" "${BUILDMODEMSG} does not generate ASF License warnings."

--- a/precommit/src/main/shell/test-patch.d/checkstyle.sh
+++ b/precommit/src/main/shell/test-patch.d/checkstyle.sh
@@ -431,7 +431,7 @@ function checkstyle_postapply
     if [[ "${BUILDMODE}" = full ]]; then
       touch  "${PATCH_DIR}/branch-checkstyle-${fn}.txt"
       cp -p "${PATCH_DIR}/patch-checkstyle-${fn}.txt" \
-        "${PATCH_DIR}/diff-checkstyle-${fn}.txt"
+        "${PATCH_DIR}/results-checkstyle-${fn}.txt"
     else
 
       # call calcdiffs to allow overrides
@@ -439,7 +439,7 @@ function checkstyle_postapply
         "${PATCH_DIR}/branch-checkstyle-${fn}.txt" \
         "${PATCH_DIR}/patch-checkstyle-${fn}.txt" \
         checkstyle \
-        > "${PATCH_DIR}/diff-checkstyle-${fn}.txt"
+        > "${PATCH_DIR}/results-checkstyle-${fn}.txt"
     fi
 
     tmpvar=$(wc -l "${PATCH_DIR}/branch-checkstyle-${fn}.txt")
@@ -448,7 +448,7 @@ function checkstyle_postapply
     tmpvar=$(wc -l "${PATCH_DIR}/patch-checkstyle-${fn}.txt")
     numpatch=${tmpvar%% *}
 
-    tmpvar=$(wc -l "${PATCH_DIR}/diff-checkstyle-${fn}.txt")
+    tmpvar=$(wc -l "${PATCH_DIR}/results-checkstyle-${fn}.txt")
     addpatch=${tmpvar%% *}
 
 
@@ -463,9 +463,9 @@ function checkstyle_postapply
 
     if [[ ${addpatch} -gt 0 ]] ; then
       ((result = result + 1))
-      module_status "${i}" -1 "diff-checkstyle-${fn}.txt" "${mod}: ${BUILDMODEMSG} ${statstring}"
+      module_status "${i}" -1 "results-checkstyle-${fn}.txt" "${mod}: ${BUILDMODEMSG} ${statstring}"
     elif [[ ${fixedpatch} -gt 0 ]]; then
-      module_status "${i}" +1 "diff-checkstyle-${fn}.txt" "${mod}: ${BUILDMODEMSG} ${statstring}"
+      module_status "${i}" +1 "results-checkstyle-${fn}.txt" "${mod}: ${BUILDMODEMSG} ${statstring}"
       summarize=false
     fi
     ((i=i+1))

--- a/precommit/src/main/shell/test-patch.d/pathlen.sh
+++ b/precommit/src/main/shell/test-patch.d/pathlen.sh
@@ -71,7 +71,7 @@ function pathlen_generic
     size=${#i}
     if [[ ${size} -gt ${PATHLEN_SIZE} ]]; then
       ((counter = counter + 1 ))
-      echo "${i}" >>  "${PATCH_DIR}/pathlen.txt"
+      echo "${i}:1:path size ${counter}" >>  "${PATCH_DIR}/results-pathlen.txt"
     fi
   done
 
@@ -79,8 +79,9 @@ function pathlen_generic
   echo "${counter} files in the ${msg} with paths longer that ${PATHLEN_SIZE}."
   if [[ ${counter} -gt 0 ]] ; then
     add_vote_table_v2 -1 pathlen \
-      "@@BASE@@/pathlen.txt" \
+      "@@BASE@@/results-pathlen.txt" \
       "${BUILDMODEMSG} appears to contain ${counter} files with names longer than ${PATHLEN_SIZE}"
+    bugsystem_linecomments_queue pathlen "${PATCH_DIR}/results-pathlen.txt"
     return 1
   fi
   return 0

--- a/precommit/src/main/shell/test-patch.d/unitveto.sh
+++ b/precommit/src/main/shell/test-patch.d/unitveto.sh
@@ -19,6 +19,7 @@
 add_test_type unitveto
 
 UNITVETO_RE=${UNITVETO_RE:-}
+UNITVETO_LOGFILE="results-unitveto.txt"
 
 function unitveto_filefilter
 {
@@ -27,6 +28,8 @@ function unitveto_filefilter
   if [[ -n "${UNITVETO_RE}"
      && ${filename} =~ ${UNITVETO_RE} ]]; then
     yetus_debug "unitveto: ${filename} matched"
+    echo "${filename}:1:0:unitveto:matches ${UNITVETO_RE}" \
+      >> "${PATCH_DIR}/${UNITVETO_LOGFILE}"
     add_test unitveto
   fi
 }
@@ -60,6 +63,7 @@ function unitveto_patchfile
     return 0
   fi
 
-  add_vote_table_v2 -1 unitveto "" "Patch requires manual testing."
+  add_vote_table_v2 -1 unitveto "@@BASE@@/${UNITVETO_LOGFILE}" "Patch requires manual testing."
+  bugsystem_linecomments_queue unitveto "${PATCH_DIR}/${UNITVETO_LOGFILE}"
   return 1
 }


### PR DESCRIPTION
* Added group control to github actions output to make it
  easier to debug
* Changed the remaining diff- to results-
* Reformatted asflicense output, now calls b_l_queue
* Reformatted author output (where possible), now calls b_l_queue
* Reformatted dupname output, now calls b_l_queue
* Reformatted maven javac output, now uses column_calcdiffs
* Reformatted maven javadoc output, now users error_calcdiffs
* Reformatted pathlen output, now calls b_l_queue
* Reformatted unitveto output, now cals b_l_queue
* b_l_queue rejects plug-ins that are in the tests filter
* b_l_queue verifies that the first column exists
* modules_messages now calls b_l_queue

There are likely other plug-ins that will need massaging
(esp ant and gradle), but this covers a good chunk of missing
functionality for the most users.