### PR TITLE
YETUS-1094. Load the personality file before loading plugins.

### DIFF
--- a/precommit/src/main/shell/core.d/01-common.sh
+++ b/precommit/src/main/shell/core.d/01-common.sh
@@ -587,7 +587,7 @@ function importplugins
   if [[ -f ${PERSONALITY} ]]; then
     yetus_debug "Importing ${PERSONALITY}"
     # shellcheck disable=SC1090
-    files+=("${PERSONALITY}")
+    . "${PERSONALITY}"
   else
     if [[ "${PERSONALITY}" != "${BASEDIR}/.yetus/personality.sh" ]]; then
       yetus_error "ERROR: ${PERSONALITY} does not exist."


### PR DESCRIPTION
[YETUS-1072](https://issues.apache.org/jira/browse/YETUS-1072) (#207) unintentionally changed the order of loading plugins and personality.

* Before: personality -> plugins -> user_plugins
* After: plugins -> user_plugins -> personality

A plugin can be loaded successfully only after the plugin is enabled by `--plugins` command line option or `personality_plugins` function which is called in a personality file. Therefore a personality file should be loaded before loading plugins.

JIRA: https://issues.apache.org/jira/browse/YETUS-1094