### PR TITLE
YETUS-1106. Detect CMake test changes

### DIFF
--- a/precommit/src/main/shell/plugins.d/test4tests.sh
+++ b/precommit/src/main/shell/plugins.d/test4tests.sh
@@ -41,7 +41,7 @@ function test4tests_patchfile
   start_clock
 
   for i in "${CHANGED_FILES[@]}"; do
-    if [[ ${i} =~ (^|/)test/ ]]; then
+    if [[ ${i} =~ (^|/)tests?/ ]]; then
       ((testReferences=testReferences + 1))
     fi
   done


### PR DESCRIPTION
* The regex used to detect test changes
  only caters to the case where there's
  a directory named "test".
* Conventionally, the tests in CMake are
  put under a directory named "tests".
  This causes the regex match to fail and
  thus results in a -1 for test4tests.
* We handle this case by matching "test"
  with an optional trailing "s".