### PR TITLE
Fixes YETUS-1116. Documentation for blank-test incorrect

### DIFF
--- a/asf-site-src/source/documentation/in-progress/precommit/plugins/blanks.html.md
+++ b/asf-site-src/source/documentation/in-progress/precommit/plugins/blanks.html.md
@@ -43,7 +43,7 @@ None
 | Option | Notes |
 |:---------|:------|
 | `--blanks-eol-ignore-file=<file>` | File containing regexs of files/dirs to ignore EOL blanks. Defaults to `.yetus/blanks-eol.txt` |
-| `--blanks-tabs-ignore-file=<file>` | File containing regexs of files/dirs to ignore tabs. Defaults to `.yetus/blanks-eol.txt` |
+| `--blanks-tabs-ignore-file=<file>` | File containing regexs of files/dirs to ignore tabs. Defaults to `.yetus/blanks-tabs.txt` |
 
 # Docker Notes
 


### PR DESCRIPTION
The documentation incorrectly listed `.yetus/blanks-eol.txt` as the default ignore file for the blank-tabs-test. It should be `.yetus/blanks-tabs.txt`. 

This PR fixes that.