### PR TITLE
YETUS-1107. calcdiffs of cc raise false positive warnings.

### DIFF
--- a/precommit/src/main/shell/plugins.d/cc.sh
+++ b/precommit/src/main/shell/plugins.d/cc.sh
@@ -68,9 +68,5 @@ function cc_logfilter
   declare output=$2
 
   #shellcheck disable=SC1117
-  "${GREP}" -i -E "^.*\.${CC_EXT_RE}\:[[:digit:]]*\:" "${input}" \
-   | "${SED}" -E -e 's,\[(ERROR|WARNING)\] ,,g' \
-                 -e "s,^${BASEDIR}/,," \
-   | sort \
-   > "${output}"
+  "${GREP}" -i -E "^.*\.${CC_EXT_RE}\:[[:digit:]]*\:" "${input}" > "${output}"
 }

--- a/precommit/src/main/shell/plugins.d/maven.sh
+++ b/precommit/src/main/shell/plugins.d/maven.sh
@@ -834,3 +834,23 @@ function maven_reorder_modules
   # shellcheck disable=SC2046
   echo "Elapsed: $(clock_display $(stop_clock))"
 }
+
+## @description  process cc output from maven
+## @audience     private
+## @stability    evolving
+function maven_cc_logfilter
+{
+  declare input=$1
+  declare output=$2
+
+  # [WARNING] fullpath:linenum:column: message
+
+  "${GREP}" -i -E "^.*\.${CC_EXT_RE}\:[[:digit:]]*\:" "${input}" \
+    | "${SED}" -E -e 's,\[(ERROR|WARNING)\] ,,g' \
+    | "${GREP}" -i -E "^/" \
+    | "${SED}" -e "s,^${BASEDIR}/,," \
+    | sort \
+    > "${output}"
+
+  # shortpath:linenum:column: message
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/YETUS-1107

The cause is parallel mode of make/cmake (-j) generating warnings in non-deterministic order. Sorting the grepped output should mitigate this.