### PR TITLE
YETUS-1155: Fix site:site treeset problem

### DIFF
--- a/audience-annotations-component/audience-annotations/src/main/java/org/apache/yetus/audience/tools/DocletEnvironmentProcessor.java
+++ b/audience-annotations-component/audience-annotations/src/main/java/org/apache/yetus/audience/tools/DocletEnvironmentProcessor.java
@@ -17,19 +17,11 @@
  */
 package org.apache.yetus.audience.tools;
 
-import com.sun.source.util.DocTrees;
 import jdk.javadoc.doclet.DocletEnvironment;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
-import javax.lang.model.util.Types;
-import javax.tools.JavaFileManager;
-import javax.tools.JavaFileObject;
-import java.util.Set;
 
 class DocletEnvironmentProcessor {
   private boolean treatUnannotatedClassesAsPrivate = false;
@@ -43,106 +35,61 @@ class DocletEnvironmentProcessor {
     this.stability = stabilityOption;
   }
 
-  DocletEnvironment wrap(final DocletEnvironment environment) {
-    return new DocletEnvironment() {
-      @Override
-      public Set<? extends Element> getSpecifiedElements() {
-        return environment.getSpecifiedElements();
-      }
+  /**
+   * Wrapper class that overrides the set of included elements.
+   * The HtmlDoclet downcasts the parameter to a DocEnvImpl, so we
+   * have to subclass that.
+   */
+  class DocEnvImpl extends jdk.javadoc.internal.tool.DocEnvImpl {
+    DocEnvImpl(jdk.javadoc.internal.tool.DocEnvImpl environment) {
+      super(environment.toolEnv, environment.etable);
+    }
 
-      @Override
-      public Set<? extends Element> getIncludedElements() {
-        // TODO Do we need to handle exclusions here too?
-        return environment.getIncludedElements();
-      }
+    @Override
+    public boolean isIncluded(final Element e) {
+      return !excluded(e) && super.isIncluded(e);
+    }
 
-      @Override
-      public DocTrees getDocTrees() {
-        return environment.getDocTrees();
-      }
-
-      @Override
-      public Elements getElementUtils() {
-        return environment.getElementUtils();
-      }
-
-      @Override
-      public Types getTypeUtils() {
-        return environment.getTypeUtils();
-      }
-
-      @Override
-      public boolean isIncluded(final Element e) {
-        return !excluded(e) && environment.isIncluded(e);
-      }
-
-      @Override
-      public boolean isSelected(final Element e) {
-        return environment.isSelected(e);
-      }
-
-      @Override
-      public JavaFileManager getJavaFileManager() {
-        return environment.getJavaFileManager();
-      }
-
-      @Override
-      public SourceVersion getSourceVersion() {
-        return environment.getSourceVersion();
-      }
-
-      @Override
-      public ModuleMode getModuleMode() {
-        return environment.getModuleMode();
-      }
-
-      @Override
-      public JavaFileObject.Kind getFileKind(final TypeElement type) {
-        return environment.getFileKind(type);
-      }
-
-      /**
-       * Check if an element should be excluded by our annotation rules
-       * @param e the element to check
-       * @return true iff the element should be excluded
-       */
-      private boolean excluded(final Element e) {
-        // Exclude private and limited private types
-        if (e.getAnnotation(InterfaceAudience.Private.class) != null) {
-          return true;
-        }
-        if (e.getAnnotation(InterfaceAudience.LimitedPrivate.class) != null) {
-          return true;
-        }
-        if (e.getAnnotation(InterfaceAudience.Public.class) == null) {
-          // No audience annotations
-          if (treatUnannotatedClassesAsPrivate) {
-            // Exclude classes and interfaces if they are not annotated
-            return e.getKind().isClass() || e.getKind().isInterface();
-          }
-        }
-
-        // At this point, everything is either public audience or unannotated
-        // and treat-as-public, which means they must have a stability
-        // annotation as well.
-
-        // Filter types based on stability
-        if (e.getAnnotation(InterfaceStability.Unstable.class) != null) {
-          return stability == StabilityOption.STABLE
-                  || stability == StabilityOption.EVOLVING;
-        }
-        if (e.getAnnotation(InterfaceStability.Evolving.class) != null) {
-          return stability == StabilityOption.STABLE;
-        }
-        if (e.getAnnotation(InterfaceStability.Stable.class) != null) {
-          // public or treat-as-public
-          return false;
-        }
-
-        // Public, but no stability? This is an error, so we exclude
+    /**
+     * Check if an element should be excluded by our annotation rules
+     * @param e the element to check
+     * @return true iff the element should be excluded
+     */
+    private boolean excluded(final Element e) {
+      // Exclude private and limited private types
+      if (e.getAnnotation(InterfaceAudience.Private.class) != null) {
         return true;
       }
-    };
+      if (e.getAnnotation(InterfaceAudience.LimitedPrivate.class) != null) {
+        return true;
+      }
+      if (e.getAnnotation(InterfaceAudience.Public.class) == null) {
+        // No audience annotations
+        if (treatUnannotatedClassesAsPrivate) {
+          // Exclude classes and interfaces if they are not annotated
+          return e.getKind().isClass() || e.getKind().isInterface();
+        }
+      }
+
+      // At this point, everything is either public audience or unannotated
+      // and treat-as-public, which means they must have a stability
+      // annotation as well.
+
+      // Filter types based on stability
+      if (e.getAnnotation(InterfaceStability.Unstable.class) != null) {
+        return stability == StabilityOption.STABLE
+            || stability == StabilityOption.EVOLVING;
+      }
+      if (e.getAnnotation(InterfaceStability.Evolving.class) != null) {
+        return stability == StabilityOption.STABLE;
+      }
+      // Public, but no stability? This is an error, so we exclude
+      return e.getAnnotation(InterfaceStability.Stable.class) == null;
+    }
+  }
+
+  DocletEnvironment wrap(final DocletEnvironment environment) {
+    return new DocEnvImpl((jdk.javadoc.internal.tool.DocEnvImpl) environment);
   }
 
 }

--- a/audience-annotations-component/audience-annotations/src/main/java/org/apache/yetus/audience/tools/ExcludePrivateAnnotationsStandardDoclet.java
+++ b/audience-annotations-component/audience-annotations/src/main/java/org/apache/yetus/audience/tools/ExcludePrivateAnnotationsStandardDoclet.java
@@ -23,6 +23,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -45,7 +46,7 @@ public class ExcludePrivateAnnotationsStandardDoclet extends StandardDoclet {
 
   @Override
   public Set<Option> getSupportedOptions() {
-    Set<Option> options = new TreeSet<>(super.getSupportedOptions());
+    Set<Option> options = new HashSet<>(super.getSupportedOptions());
     Set<StabilityOption> stabilityOptions = EnumSet.allOf(StabilityOption.class);
     stabilityOptions.forEach(o -> o.setProcessor(processor));
     options.addAll(stabilityOptions);

--- a/audience-annotations-component/audience-annotations/src/test/java/org/apache/yetus/audience/tools/DocletEnvironmentProcessorTest.java
+++ b/audience-annotations-component/audience-annotations/src/test/java/org/apache/yetus/audience/tools/DocletEnvironmentProcessorTest.java
@@ -18,6 +18,8 @@
 package org.apache.yetus.audience.tools;
 
 import jdk.javadoc.doclet.DocletEnvironment;
+import jdk.javadoc.internal.tool.DocEnvImpl;
+import jdk.javadoc.internal.tool.ElementsTable;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,8 +46,10 @@ public class DocletEnvironmentProcessorTest {
     @BeforeEach
     public void setup() {
         processor = new DocletEnvironmentProcessor();
-        DocletEnvironment mockEnvironment = mock(DocletEnvironment.class);
-        when(mockEnvironment.isIncluded(any())).thenReturn(true);
+        ElementsTable mockElements = mock(ElementsTable.class);
+        DocletEnvironment mockEnvironment =
+            new DocEnvImpl(null, mockElements);
+        when(mockElements.isIncluded(any())).thenReturn(true);
         environment = processor.wrap(mockEnvironment);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
 
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <project.build.outputTimestamp>n</project.build.outputTimestamp>
+    <jigsaw.avoidance>--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</jigsaw.avoidance>
   </properties>
 
   <scm>
@@ -141,6 +142,8 @@
           <version>${maven-javadoc-plugin.version}</version>
           <configuration>
             <notimestamp>true</notimestamp><!-- avoid noise for svn/gitpubsub -->
+            <additionalOptions>${jigsaw.avoidance}</additionalOptions>
+            <additionalJOption>-J${jigsaw.avoidance}</additionalJOption>
           </configuration>
         </plugin>
 
@@ -148,6 +151,26 @@
           <artifactId>maven-clean-plugin</artifactId>
           <configuration>
             <failOnError>false</failOnError>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.10.1</version>
+          <configuration>
+            <compilerArgs>
+              <arg>${jigsaw.avoidance}</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version>
+          <configuration>
+            <argLine>${jigsaw.avoidance}</argLine>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
Fixes the first problem that was caused because the yetus options weren't comparable to the standard option objects. I changed the TreeSet to a HashSet, which does not require more than hashCode & equals.