### PR TITLE
YETUS-1159. fixes for CVE-2022-24765

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@
 
 yetus_task:
   container:
-    image: apache/yetus:main
+    image: ghcr.io/apache/yetus:main
   test_script: >
              ${CIRRUS_WORKING_DIR}/precommit/src/main/shell/test-patch.sh
              --basedir="${CIRRUS_WORKING_DIR}"

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: src
           fetch-depth: 0
       - name: maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: yetus-m2-${{ hashFiles('**/pom.xml') }}
@@ -45,7 +45,7 @@ jobs:
           testsfilter: checkstyle,test4tests
       - name: Artifact output
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: apacheyetustestpatchactionout
           path: ${{ github.workspace }}/out

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: src
           fetch-depth: 0

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: yetus-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/yetus.yml
+++ b/.github/workflows/yetus.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: src
           fetch-depth: 0
       - name: maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: yetus-m2-${{ hashFiles('**/pom.xml') }}
@@ -60,7 +60,7 @@ jobs:
           --tests-filter=checkstyle,javadoc,rubocop,test4tests
       - name: Artifact output
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: apacheyetuspatchdir
           path: ${{ github.workspace }}/out

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@
 ---
 
 buretoolbox-job:
-  image: apache/yetus:main
+  image: ghcr.io/apache/yetus:main
   allow_failure: true
   script:
     - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
     --patch-dir=/tmp/yetus-out
     --java-home=/usr/lib/jvm/java-11-openjdk-amd64
     --plugins=all,-detsecrets
-    --docker-cache-from=apache/yetus:main
+    --docker-cache-from=ghcr.io/apache/yetus:main
     --html-report-file=/tmp/yetus-out/report.html
     --console-report-file=/tmp/yetus-out/console.txt
     --brief-report-file=/tmp/yetus-out/brief.txt

--- a/asf-site-src/source/documentation/in-progress/precommit/robots/githubactions.html.md
+++ b/asf-site-src/source/documentation/in-progress/precommit/robots/githubactions.html.md
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: src
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
           githubtoken: ${{ secrets.GITHUB_TOKEN }}
       - name: Artifact output
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: apacheyetuspatchdir
           path: ${{ github.workspace }}/out

--- a/precommit/src/main/shell/core.d/01-common.sh
+++ b/precommit/src/main/shell/core.d/01-common.sh
@@ -299,6 +299,17 @@ function common_args
     cleanup_and_exit 1
   fi
 
+  PERSONALITY="${BASEDIR}/.yetus/personality.sh"
+  USER_PLUGIN_DIR="${BASEDIR}/.yetus/plugins.d"
+}
+
+## @description  Verify that BASEDIR is a git repo
+## @description  and set some git settings
+## @audience     public
+## @stability    evolving
+## @replaceable  no
+function verify_basedir_repo
+{
   if [[ ! -e "${BASEDIR}/.git" ]]; then
     yetus_error "ERROR: ${BASEDIR} is not a git repo."
     cleanup_and_exit 1
@@ -311,9 +322,6 @@ function common_args
     GIT_CEILING_DIRECTORIES="${BASEDIR}"
     export GIT_CEILING_DIRECTORIES
   fi
-
-  PERSONALITY="${BASEDIR}/.yetus/personality.sh"
-  USER_PLUGIN_DIR="${BASEDIR}/.yetus/plugins.d"
 }
 
 ## @description  List all installed plug-ins, regardless of whether

--- a/precommit/src/main/shell/core.d/01-common.sh
+++ b/precommit/src/main/shell/core.d/01-common.sh
@@ -303,12 +303,13 @@ function common_args
   USER_PLUGIN_DIR="${BASEDIR}/.yetus/plugins.d"
 }
 
-## @description  Verify that BASEDIR is a git repo
+## @description  Check BASEDIR is a git repo
 ## @description  and set some git settings
-## @audience     public
+## @audience     private
 ## @stability    evolving
 ## @replaceable  no
-function verify_basedir_repo
+## @return       May exit on failure
+function check_basedir_repo
 {
   if [[ ! -e "${BASEDIR}/.git" ]]; then
     yetus_error "ERROR: ${BASEDIR} is not a git repo."

--- a/precommit/src/main/shell/core.d/01-common.sh
+++ b/precommit/src/main/shell/core.d/01-common.sh
@@ -299,6 +299,19 @@ function common_args
     cleanup_and_exit 1
   fi
 
+  if [[ ! -e "${BASEDIR}/.git" ]]; then
+    yetus_error "ERROR: ${BASEDIR} is not a git repo."
+    cleanup_and_exit 1
+  fi
+
+  if yetus_is_container; then
+    GIT_DIR="${BASEDIR}/.git"
+    export GIT_DIR
+
+    GIT_CEILING_DIRECTORIES="${BASEDIR}"
+    export GIT_CEILING_DIRECTORIES
+  fi
+
   PERSONALITY="${BASEDIR}/.yetus/personality.sh"
   USER_PLUGIN_DIR="${BASEDIR}/.yetus/plugins.d"
 }

--- a/precommit/src/main/shell/robots.d/cirrusci.sh
+++ b/precommit/src/main/shell/robots.d/cirrusci.sh
@@ -71,7 +71,7 @@ if [[ "${CIRRUS_CI}" == true ]] &&
 
   if [[ -d ${BASEDIR}/.git ]]; then
 
-    verify_basedir_repo
+    check_basedir_repo
 
     echo "Updating the local git repo to include all branches/tags:"
     pushd "${BASEDIR}" >/dev/null || exit 1

--- a/precommit/src/main/shell/robots.d/cirrusci.sh
+++ b/precommit/src/main/shell/robots.d/cirrusci.sh
@@ -70,6 +70,9 @@ if [[ "${CIRRUS_CI}" == true ]] &&
   CONSOLE_USE_BUILD_URL=true
 
   if [[ -d ${BASEDIR}/.git ]]; then
+
+    verify_basedir_repo
+
     echo "Updating the local git repo to include all branches/tags:"
     pushd "${BASEDIR}" >/dev/null || exit 1
     "${GIT}" config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*

--- a/precommit/src/main/shell/robots.d/travisci.sh
+++ b/precommit/src/main/shell/robots.d/travisci.sh
@@ -74,6 +74,9 @@ if [[ "${TRAVIS}" == true ]] &&
   CONSOLE_USE_BUILD_URL=true
 
   if [[ -d ${BASEDIR}/.git ]]; then
+
+    verify_basedir_repo
+
     echo "Updating the local git repo to include all branches/tags:"
     pushd "${BASEDIR}" >/dev/null || exit 1
     "${GIT}" config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*

--- a/precommit/src/main/shell/robots.d/travisci.sh
+++ b/precommit/src/main/shell/robots.d/travisci.sh
@@ -75,7 +75,7 @@ if [[ "${TRAVIS}" == true ]] &&
 
   if [[ -d ${BASEDIR}/.git ]]; then
 
-    verify_basedir_repo
+    check_basedir_repo
 
     echo "Updating the local git repo to include all branches/tags:"
     pushd "${BASEDIR}" >/dev/null || exit 1

--- a/precommit/src/main/shell/smart-apply-patch.sh
+++ b/precommit/src/main/shell/smart-apply-patch.sh
@@ -191,7 +191,7 @@ function parse_args
 
   common_args "$@"
 
-  verify_basedir_repo
+  check_basedir_repo
 
   for i in "$@"; do
     case ${i} in

--- a/precommit/src/main/shell/smart-apply-patch.sh
+++ b/precommit/src/main/shell/smart-apply-patch.sh
@@ -191,6 +191,8 @@ function parse_args
 
   common_args "$@"
 
+  verify_basedir_repo
+
   for i in "$@"; do
     case ${i} in
       --build-tool=*)

--- a/precommit/src/main/shell/test-patch.sh
+++ b/precommit/src/main/shell/test-patch.sh
@@ -760,6 +760,8 @@ function parse_args
 
   common_args "$@"
 
+  verify_basedir_repo
+
   for i in "$@"; do
     case ${i} in
       --archive-list=*)
@@ -966,6 +968,10 @@ function parse_args
     RUN_TESTS=true
     ISSUE=${PATCH_OR_ISSUE}
     yetus_add_array_element EXEC_MODES Robot
+  fi
+
+  if yetus_is_container; then
+    yetus_add_array_element EXEC_MODES InContainer
   fi
 
   if [[ -n $UNIT_TEST_FILTER_FILE ]]; then
@@ -3080,6 +3086,8 @@ function initialize
   setup_defaults
 
   parse_args "$@"
+
+  verify_basedir_repo
 
   importplugins
 

--- a/precommit/src/main/shell/test-patch.sh
+++ b/precommit/src/main/shell/test-patch.sh
@@ -1171,10 +1171,6 @@ function git_checkout
   fi
 
   cd "${BASEDIR}" || cleanup_and_exit 1
-  if [[ ! -e .git ]]; then
-    yetus_error "ERROR: ${BASEDIR} is not a git repo."
-    cleanup_and_exit 1
-  fi
 
   if [[ ${RESETREPO} == "true" ]] ; then
 

--- a/precommit/src/main/shell/test-patch.sh
+++ b/precommit/src/main/shell/test-patch.sh
@@ -760,7 +760,7 @@ function parse_args
 
   common_args "$@"
 
-  verify_basedir_repo
+  check_basedir_repo
 
   for i in "$@"; do
     case ${i} in
@@ -3087,7 +3087,7 @@ function initialize
 
   parse_args "$@"
 
-  verify_basedir_repo
+  check_basedir_repo
 
   importplugins
 

--- a/release/initial-patches.sh
+++ b/release/initial-patches.sh
@@ -89,7 +89,7 @@ docker_run() {
     -u "${USER_ID}" \
     -e "HOME=${HOME}" \
     -w /src \
-    "apache/yetus:main" \
+    "ghcr.io/apache/yetus:main" \
     "$@"
 }
 


### PR DESCRIPTION
This patch does a few things:

* updates various github actions to the latest versions which help fix things on the Github-side
* Adds a new yetus_is_container feature routine which helps us figure out if code is running in a container
* Moves the BASEDIR/.git check to be in routine in common
* If precommit is running in a container, set GIT_DIR and GIT_CEILING_DIRECTORIES which will prevent git from going past our source tree.  We do not set these outside of the container because there is an assumption the user knows what they are doing.
* Associated documentation

NOTE: this code will almost certainly still fail the Action Test GHA until it is committed to main.