### PR TITLE
YETUS-1166. Add jsonlint support (addendum)

### DIFF
--- a/asf-site-src/source/documentation/in-progress/precommit/index.html.md
+++ b/asf-site-src/source/documentation/in-progress/precommit/index.html.md
@@ -144,6 +144,7 @@ Language Support, Licensing, and more:
 * [golangci-lint](plugins/golangcilint)
 * [hadolint](plugins/hadolint)
 * [jshint](plugins/jshint)
+* [jsonlint](plugins/jsonlint)
 * [markdownlint-cli](plugins/markdownlint)
 * [Perl::Critic](plugins/perlcritic)
 * [pylint](plugins/pylint)


### PR DESCRIPTION
Forgot to link the docs from the main index. woops.