### PR TITLE
YETUS-1191. Add uniq-by-line option to golangci

### DIFF
--- a/precommit/src/main/shell/plugins.d/golangci.sh
+++ b/precommit/src/main/shell/plugins.d/golangci.sh
@@ -85,6 +85,7 @@ function golangcilint_exec
 
   args+=("--max-issues-per-linter=0")
   args+=("--max-same-issues=0")
+  args+=("--uniq-by-line=false")
   args+=("--out-format=line-number")
   args+=("--print-issued-lines=false")
   args+=("--color=never")


### PR DESCRIPTION
In order to have all complains in results of golangci we should set
uniq-by-line to false. Having uniq-by-line equals true (default) force
golangci to output only the first error per line comes from linters in
random order. Random errors give us unpredictable diff between branch
and patch results.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>