### PR TITLE
YETUS-1199. Add ability to ignore hadolint warnings

### DIFF
--- a/precommit/src/main/shell/plugins.d/hadolint.sh
+++ b/precommit/src/main/shell/plugins.d/hadolint.sh
@@ -122,8 +122,10 @@ function hadolint_logic
     args=(--no-color)
   fi
 
-  prefix="--ignore "
-  ignorelist="${HADOLINT_IGNORE_LIST[*]/#/$prefix}"
+  if [[ -n "${HADOLINT_IGNORE_LIST}" ]]; then
+    prefix="--ignore "
+    args+=("${HADOLINT_IGNORE_LIST[*]/#/$prefix}")
+  fi
 
   for i in "${HADOLINT_CHECKFILES[@]}"; do
     if [[ -f "${i}" ]]; then
@@ -137,7 +139,6 @@ function hadolint_logic
       # shellcheck disable=SC2016
       "${HADOLINT}" \
         "${args[@]}" \
-        "${ignorelist}" \
         "${i}" \
         | "${AWK}" '{printf "%s:",$1; $1=""; print $0}' \
         >> "${PATCH_DIR}/${repostatus}-hadolint-result.txt"

--- a/precommit/src/main/shell/plugins.d/hadolint.sh
+++ b/precommit/src/main/shell/plugins.d/hadolint.sh
@@ -107,6 +107,7 @@ function hadolint_logic
       # shellcheck disable=SC2016
       "${HADOLINT}" \
         "${args[@]}" \
+        --ignore DL3059 \
         "${i}" \
         | "${AWK}" '{printf "%s:",$1; $1=""; print $0}' \
         >> "${PATCH_DIR}/${repostatus}-hadolint-result.txt"


### PR DESCRIPTION
* This PR adds the option
  --hadolint-ignore-list which
  can be used to ignore the
  warnings detected by
  hadolint.