### PR TITLE
YETUS-1200. Add ability to exclude files from hadolint

### DIFF
--- a/precommit/src/main/shell/plugins.d/hadolint.sh
+++ b/precommit/src/main/shell/plugins.d/hadolint.sh
@@ -30,7 +30,7 @@ function hadolint_filefilter
 {
   declare filename=$1
 
-  if [[ -n ${HADOLINT_IGNORE_FILES} && ${filename} =~ ${HADOLINT_IGNORE_FILES} ]]; then
+  if [[ -n ${HADOLINT_IGNORE_FILE} && ${filename} =~ ${HADOLINT_IGNORE_FILE} ]]; then
     return
   elif [[ ${filename} =~ Dockerfile ]]; then
     add_test hadolint
@@ -44,7 +44,7 @@ function hadolint_filefilter
 ## @replaceable  no
 function hadolint_usage
 {
-  yetus_add_option "--hadolint-ignore-files=<file>" "Excludes the files containing this substring from hadolint"
+  yetus_add_option "--hadolint-ignore-file=<file>" "Excludes the files containing this substring from hadolint"
 }
 
 ## @description  hadolint parse args hook
@@ -58,7 +58,7 @@ function hadolint_parse_args
   for i in "$@"; do
     case ${i} in
       --hadolint-ignore-file=*)
-        HADOLINT_IGNORE_FILES="${i#*=}"
+        HADOLINT_IGNORE_FILE="${i#*=}"
         delete_parameter "${i}"
       ;;
     esac

--- a/precommit/src/main/shell/plugins.d/hadolint.sh
+++ b/precommit/src/main/shell/plugins.d/hadolint.sh
@@ -30,7 +30,7 @@ function hadolint_filefilter
 {
   declare filename=$1
 
-  if [[ ${filename} =~ ${HADOLINT_IGNORE_FILE} ]]; then
+  if [[ -n ${HADOLINT_IGNORE_FILES} && ${filename} =~ ${HADOLINT_IGNORE_FILES} ]]; then
     return
   elif [[ ${filename} =~ Dockerfile ]]; then
     add_test hadolint
@@ -44,7 +44,7 @@ function hadolint_filefilter
 ## @replaceable  no
 function hadolint_usage
 {
-  yetus_add_option "--hadolint-ignore-file=<file>" "Excludes this file from hadolint"
+  yetus_add_option "--hadolint-ignore-files=<file>" "Excludes the files containing this substring from hadolint"
 }
 
 ## @description  hadolint parse args hook
@@ -58,7 +58,7 @@ function hadolint_parse_args
   for i in "$@"; do
     case ${i} in
       --hadolint-ignore-file=*)
-        HADOLINT_IGNORE_FILE="${i#*=}"
+        HADOLINT_IGNORE_FILES="${i#*=}"
         delete_parameter "${i}"
       ;;
     esac

--- a/precommit/src/main/shell/plugins.d/hadolint.sh
+++ b/precommit/src/main/shell/plugins.d/hadolint.sh
@@ -30,9 +30,7 @@ function hadolint_filefilter
 {
   declare filename=$1
 
-  if [[ -n ${HADOLINT_IGNORE_FILE} && ${filename} =~ ${HADOLINT_IGNORE_FILE} ]]; then
-    return
-  elif [[ ${filename} =~ Dockerfile ]]; then
+  if [[ ${filename} =~ Dockerfile ]]; then
     add_test hadolint
     yetus_add_array_element HADOLINT_CHECKFILES "${filename}"
   fi
@@ -125,6 +123,11 @@ function hadolint_logic
   fi
 
   for i in "${HADOLINT_CHECKFILES[@]}"; do
+    if [[ -n ${HADOLINT_IGNORE_FILE} && ${i} =~ ${HADOLINT_IGNORE_FILE} ]]; then
+      yetus_debug "Skipping ${i} for hadolint"
+      continue
+    fi
+
     if [[ -f "${i}" ]]; then
 
       ## transform from

--- a/precommit/src/main/shell/plugins.d/hadolint.sh
+++ b/precommit/src/main/shell/plugins.d/hadolint.sh
@@ -30,10 +30,39 @@ function hadolint_filefilter
 {
   declare filename=$1
 
-  if [[ ${filename} =~ Dockerfile ]]; then
+  if [[ ${filename} =~ ${HADOLINT_IGNORE_FILE} ]]; then
+    return
+  elif [[ ${filename} =~ Dockerfile ]]; then
     add_test hadolint
     yetus_add_array_element HADOLINT_CHECKFILES "${filename}"
   fi
+}
+
+## @description  The options available for the hadolint plugin
+## @audience     private
+## @stability    evolving
+## @replaceable  no
+function hadolint_usage
+{
+  yetus_add_option "--hadolint-ignore-file=<file>" "Excludes this file from hadolint"
+}
+
+## @description  hadolint parse args hook
+## @audience     private
+## @stability    evolving
+## @replaceable  no
+function hadolint_parse_args
+{
+  declare i
+
+  for i in "$@"; do
+    case ${i} in
+      --hadolint-ignore-file=*)
+        HADOLINT_IGNORE_FILE="${i#*=}"
+        delete_parameter "${i}"
+      ;;
+    esac
+  done
 }
 
 function hadolint_precheck


### PR DESCRIPTION
* This PR exposes an option
  `--hadolint-ignore-file` in the
  hadolint plugin.
* All the files matching this
  pattern will be excluded from
  hadolint.